### PR TITLE
Add function about interview

### DIFF
--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -49,10 +49,6 @@ class InterviewsController < ApplicationController
     redirect_to interviews_url, notice: '削除に成功しました。'
   end
 
-  def index_for_others
-    @user = User.find_by(params[:user_id])
-  end
-
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_interview
@@ -61,7 +57,6 @@ class InterviewsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def interview_params
-      p params
       params.require(:interview).permit(:date, :availability)
     end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -35,6 +35,7 @@ class InterviewsController < ApplicationController
 
   # PATCH/PUT /interviews/1
   def update
+    Interview.where(user_id: params[:user_id]).where(availability: 'accept').update_all(availability: 'reject')
     if @interview.update(interview_params)
       redirect_to @interview, notice: '更新に成功しました。'
     else
@@ -55,11 +56,12 @@ class InterviewsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_interview
-      @interview = current_user.interviews.find(params[:id])
+      @interview = Interview.find(params[:id])
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def interview_params
-      params.require(:interview).permit(:date)
+      p params
+      params.require(:interview).permit(:date, :availability)
     end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -5,7 +5,10 @@ class InterviewsController < ApplicationController
   # GET /interviews
   # GET /interviews.json
   def index
-    @user = current_user
+    @user = User.find(params[:id])
+    unless current_user == @user
+      render :index_for_others
+    end
   end
 
   # GET /interviews/1
@@ -60,6 +63,10 @@ class InterviewsController < ApplicationController
       format.html { redirect_to interviews_url, notice: '削除に成功しました。' }
       format.json { head :no_content }
     end
+  end
+
+  def index_for_others
+    @user = User.find_by(params[:user_id])
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,6 @@ class UsersController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @users = User.all
+    @users = User.where.not(id: current_user.id)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def l(*args)
+    I18n.localize(*args) unless args.first.nil?
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,5 @@
 module ApplicationHelper
+  #Accept nil values 
   def l(*args)
     I18n.localize(*args) unless args.first.nil?
   end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,6 +1,4 @@
-<%= link_to "プロフィール",  edit_user_registration_path, method: :get %>
-<%= link_to "面接一覧",  interviews_path, method: :get %>
-<%= link_to "ログアウト",  destroy_user_session_path, method: :delete %>
+<%= render :partial => 'shared/header' %>
 
 <h2>プロフィール </h2>
 

--- a/app/views/interviews/_header.html.erb
+++ b/app/views/interviews/_header.html.erb
@@ -1,5 +1,0 @@
-<p id="notice"><%= notice %></p>
-<%= link_to "e-Navigator",  root_path, method: :get %>
-<%= link_to "プロフィール",  edit_user_registration_path, method: :get %>
-<%= link_to "面接一覧",  interviews_path(id: current_user.id), method: :get %>
-<%= link_to "ログアウト",  destroy_user_session_path, method: :delete %>

--- a/app/views/interviews/_header.html.erb
+++ b/app/views/interviews/_header.html.erb
@@ -1,0 +1,5 @@
+<p id="notice"><%= notice %></p>
+<%= link_to "e-Navigator",  root_path, method: :get %>
+<%= link_to "プロフィール",  edit_user_registration_path, method: :get %>
+<%= link_to "面接一覧",  interviews_path(id: current_user.id), method: :get %>
+<%= link_to "ログアウト",  destroy_user_session_path, method: :delete %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,3 +1,4 @@
+<%= render :partial => 'shared/header' %>
 <h1>面接編集</h1>
 
 <%= render 'form', interview: @interview %>

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', interview: @interview %>
 
-<%= link_to '戻る', interviews_path %>
+<%= link_to '戻る', interviews_path(:id => @interview.user_id ) %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -14,7 +14,7 @@
   <tbody>
     <% @user.interviews.each do |interview| %>
       <tr>
-        <td><%= interview.date %></td>
+        <td><%= l(interview.date, format: :long) %></td>
         <td><%= interview.availability_i18n %></td>
         <td><%= link_to '編集', edit_interview_path(interview) %></td>
         <td><%= link_to '削除', interview, method: :delete, data: { confirm: '本当に削除しますか？' } %></td>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,7 +1,4 @@
-<p id="notice"><%= notice %></p>
-<%= link_to "プロフィール",  edit_user_registration_path, method: :get %>
-<%= link_to "面接一覧",  interviews_path, method: :get %>
-<%= link_to "ログアウト",  destroy_user_session_path, method: :delete %>
+<%= render :partial => 'shared/header' %>
 
 <h1><%= @user.name %>さんの面接一覧</h1>
 

--- a/app/views/interviews/index_for_others.html.erb
+++ b/app/views/interviews/index_for_others.html.erb
@@ -2,7 +2,8 @@
 
 <h1><%= @user.name %>さんの面接一覧</h1>
 
-<p><span class="b">現在の面接日時:</span><%= l(@user.interviews.find_by(availability: 'accept')&.date, format: :long) %></p>
+<p><span class="b">現在の面接日時:</span>
+<%= l(@user.interviews.find_by(availability: 'accept')&.date, format: :long) %></p>
 <p>面接日程を変更する場合は以下から選んでください。</p>
 
 <table>
@@ -17,7 +18,10 @@
     <% @user.interviews.each do |interview| %>
       <% if interview.date.strftime("%Y%m%d%H%M").to_i > Time.zone.now.strftime("%Y%m%d%H%M").to_i %>
         <tr>
-          <td><%= link_to l(interview.date, format: :long), interview_path(interview, params: { interview: { availability: 'accept' } }, :user_id => interview.user_id), method: :patch, data: { confirm: '面接を承認しますか？' } %></td>
+          <td><%= link_to l(interview.date, format: :long),
+          interview_path(interview, params: { interview: { availability: 'accept' } }, :user_id => interview.user_id),
+          method: :patch,
+          data: { confirm: '面接を承認しますか？' } %></td>
         </tr>
       <% end %>
     <% end %>

--- a/app/views/interviews/index_for_others.html.erb
+++ b/app/views/interviews/index_for_others.html.erb
@@ -2,7 +2,7 @@
 
 <h1><%= @user.name %>さんの面接一覧</h1>
 
-<p><span class="b">現在の面接日時:</span><%= @user.interviews.find_by(availability: 'accept')&.date %></p>
+<p><span class="b">現在の面接日時:</span><%= l(@user.interviews.find_by(availability: 'accept')&.date, format: :long) %></p>
 <p>面接日程を変更する場合は以下から選んでください。</p>
 
 <table>
@@ -16,7 +16,7 @@
   <tbody>
     <% @user.interviews.each do |interview| %>
       <tr>
-        <td><%= link_to interview.date, interview_path(interview, params: { interview: { availability: 'accept' } }, :user_id => interview.user_id), method: :patch, data: { confirm: '面接を承認しますか？' } %></td>
+        <td><%= link_to l(interview.date, format: :long), interview_path(interview, params: { interview: { availability: 'accept' } }, :user_id => interview.user_id), method: :patch, data: { confirm: '面接を承認しますか？' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/interviews/index_for_others.html.erb
+++ b/app/views/interviews/index_for_others.html.erb
@@ -2,7 +2,7 @@
 
 <h1><%= @user.name %>さんの面接一覧</h1>
 
-<p><span class="b">現在の面接日時:</span><%= l(@user.interviews.find_by(availability: 'accept')&.date, format: :long) %></p>
+<%# <p><span class="b">現在の面接日時:</span><%= l(@user.interviews.find_by(availability: 'accept')&.date, format: :long) %></p> %>
 <p>面接日程を変更する場合は以下から選んでください。</p>
 
 <table>
@@ -15,9 +15,11 @@
 
   <tbody>
     <% @user.interviews.each do |interview| %>
-      <tr>
-        <td><%= link_to l(interview.date, format: :long), interview_path(interview, params: { interview: { availability: 'accept' } }, :user_id => interview.user_id), method: :patch, data: { confirm: '面接を承認しますか？' } %></td>
-      </tr>
+      <% if interview.date.strftime("%Y%m%d%H%M").to_i > Time.zone.now.strftime("%Y%m%d%H%M").to_i %>
+        <tr>
+          <td><%= link_to l(interview.date, format: :long), interview_path(interview, params: { interview: { availability: 'accept' } }, :user_id => interview.user_id), method: :patch, data: { confirm: '面接を承認しますか？' } %></td>
+        </tr>
+      <% end %>
     <% end %>
   </tbody>
 </table>

--- a/app/views/interviews/index_for_others.html.erb
+++ b/app/views/interviews/index_for_others.html.erb
@@ -2,7 +2,7 @@
 
 <h1><%= @user.name %>さんの面接一覧</h1>
 
-<%# <p><span class="b">現在の面接日時:</span><%= l(@user.interviews.find_by(availability: 'accept')&.date, format: :long) %></p> %>
+<p><span class="b">現在の面接日時:</span><%= l(@user.interviews.find_by(availability: 'accept')&.date, format: :long) %></p>
 <p>面接日程を変更する場合は以下から選んでください。</p>
 
 <table>

--- a/app/views/interviews/index_for_others.html.erb
+++ b/app/views/interviews/index_for_others.html.erb
@@ -1,0 +1,30 @@
+<p id="notice"><%= notice %></p>
+<%= link_to "プロフィール",  edit_user_registration_path, method: :get %>
+<%= link_to "面接一覧",  interviews_path, method: :get %>
+<%= link_to "ログアウト",  destroy_user_session_path, method: :delete %>
+
+<h1><%= @user.name %>さんの面接一覧</h1>
+
+<p><span class="b">現在の面接日時:</span><%= @user.interviews.find_by(availability: 'accept') %></p>
+<p>面接日程を変更する場合は以下から選んでください。</p>
+
+<table>
+  <thead>
+    <tr>
+      <th></th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @user.interviews.each do |interview| %>
+      <tr>
+        <td><%= link_to interview.date, interview, method: :delete, data: { confirm: '本当に削除しますか？' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to '新規面接作成', new_interview_path %>

--- a/app/views/interviews/index_for_others.html.erb
+++ b/app/views/interviews/index_for_others.html.erb
@@ -2,8 +2,10 @@
 
 <h1><%= @user.name %>さんの面接一覧</h1>
 
-<p><span class="b">現在の面接日時:</span>
-<%= l(@user.interviews.find_by(availability: 'accept')&.date, format: :long) %></p>
+<p>
+  <span class="b">現在の面接日時:</span>
+  <%= l(@user.interviews.find_by(availability: 'accept')&.date, format: :long) %>
+</p>
 <p>面接日程を変更する場合は以下から選んでください。</p>
 
 <table>
@@ -18,10 +20,12 @@
     <% @user.interviews.each do |interview| %>
       <% if interview.date.strftime("%Y%m%d%H%M").to_i > Time.zone.now.strftime("%Y%m%d%H%M").to_i %>
         <tr>
-          <td><%= link_to l(interview.date, format: :long),
-          interview_path(interview, params: { interview: { availability: 'accept' } }, :user_id => interview.user_id),
-          method: :patch,
-          data: { confirm: '面接を承認しますか？' } %></td>
+          <td>
+            <%= link_to l(interview.date, format: :long),
+            interview_path(interview, params: { interview: { availability: 'accept' } }, :user_id => interview.user_id),
+            method: :patch,
+            data: { confirm: '面接を承認しますか？' } %>
+          </td>
         </tr>
       <% end %>
     <% end %>

--- a/app/views/interviews/index_for_others.html.erb
+++ b/app/views/interviews/index_for_others.html.erb
@@ -2,7 +2,7 @@
 
 <h1><%= @user.name %>さんの面接一覧</h1>
 
-<p><span class="b">現在の面接日時:</span><%= @user.interviews.find_by(availability: 'accept') %></p>
+<p><span class="b">現在の面接日時:</span><%= @user.interviews.find_by(availability: 'accept')&.date %></p>
 <p>面接日程を変更する場合は以下から選んでください。</p>
 
 <table>
@@ -16,7 +16,7 @@
   <tbody>
     <% @user.interviews.each do |interview| %>
       <tr>
-        <td><%= link_to interview.date, interview, method: :delete, data: { confirm: '本当に削除しますか？' } %></td>
+        <td><%= link_to interview.date, interview_path(interview, params: { interview: { availability: 'accept' } }, :user_id => interview.user_id), method: :patch, data: { confirm: '面接を承認しますか？' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/interviews/index_for_others.html.erb
+++ b/app/views/interviews/index_for_others.html.erb
@@ -1,7 +1,4 @@
-<p id="notice"><%= notice %></p>
-<%= link_to "プロフィール",  edit_user_registration_path, method: :get %>
-<%= link_to "面接一覧",  interviews_path, method: :get %>
-<%= link_to "ログアウト",  destroy_user_session_path, method: :delete %>
+<%= render :partial => 'shared/header' %>
 
 <h1><%= @user.name %>さんの面接一覧</h1>
 

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -2,4 +2,4 @@
 
 <%= render 'form', interview: @interview %>
 
-<%= link_to '戻る', interviews_path %>
+<%= link_to '戻る', interviews_path(:id => @interview.user_id) %>

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -11,4 +11,4 @@
 </p>
 
 <%= link_to '編集', edit_interview_path(@interview) %> |
-<%= link_to '戻る', interviews_path %>
+<%= link_to '戻る', interviews_path(:id => @interview.user_id) %>

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -2,7 +2,7 @@
 
 <p>
   <span class="b">日時:</span>
-  <%= @interview.date %>
+  <%= l(@interview.date, format: :long) %>
 </p>
 
 <p>

--- a/app/views/interviews/show.html.erb
+++ b/app/views/interviews/show.html.erb
@@ -1,4 +1,4 @@
-<p id="notice"><%= notice %></p>
+<%= render :partial => 'shared/header' %>
 
 <p>
   <span class="b">日時:</span>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,5 @@
+<p id="notice"><%= notice %></p>
+<%= link_to "e-Navigator",  root_path, method: :get %>
+<%= link_to "プロフィール",  edit_user_registration_path, method: :get %>
+<%= link_to "面接一覧",  interviews_path(id: current_user.id), method: :get %>
+<%= link_to "ログアウト",  destroy_user_session_path, method: :delete %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
-<p id="notice"><%= notice %></p>
 <%= link_to "e-Navigator",  root_path, method: :get %>
 <%= link_to "プロフィール",  edit_user_registration_path, method: :get %>
 <%= link_to "面接一覧",  interviews_path(id: current_user.id), method: :get %>
 <%= link_to "ログアウト",  destroy_user_session_path, method: :delete %>
+<p id="notice"><%= notice %></p>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,6 +1,6 @@
 <p id="notice"><%= notice %></p>
 <%= link_to "プロフィール",  edit_user_registration_path, method: :get %>
-<%= link_to "面接一覧",  interviews_path, method: :get %>
+<%= link_to "面接一覧",  interviews_path(id: current_user.id), method: :get %>
 <%= link_to "ログアウト",  destroy_user_session_path, method: :delete %>
 
 <h1>ユーザー一覧</h1>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,4 @@
-<p id="notice"><%= notice %></p>
-<%= link_to "プロフィール",  edit_user_registration_path, method: :get %>
-<%= link_to "面接一覧",  interviews_path(id: current_user.id), method: :get %>
-<%= link_to "ログアウト",  destroy_user_session_path, method: :delete %>
+<%= render :partial => 'shared/header' %>
 
 <h1>ユーザー一覧</h1>
 <table>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -23,6 +23,7 @@
         <td><%= user.age  %></td>
         <td><%= user.sex_i18n  %></td>
         <td><%= user.school  %></td>
+        <td><%= link_to "面接一覧",  interviews_path(id: user.id), method: :get %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -216,7 +216,7 @@ ja:
     am: 午前
     formats:
       default: "%Y/%m/%d %H:%M:%S"
-      long: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y年%m月%d日(%a) %H時%M分"
       short: "%y/%m/%d %H:%M"
     pm: 午後
   enums:


### PR DESCRIPTION
やりたかったこと
---

- ユーザーの一覧を表示するページの追加
- 面接官用の面接日程ページの追加
- 面接日程の承認機能の追加
- 細かな改善


やったこと
----

- ユーザーの一覧を表示するページから自分を削除
- ユーザーの一覧を表示するページに面接日程へのリンクを追加
- 面接官用の面接日程一覧ページの追加
- 面接承認機能の追加
- header 部分を独立
- 日付のフォーマットの変更



動作確認方法
---

- [ ] ユーザーを新規で作成する
- [ ] いくつかの面接を作成する
- [ ] ログアウトする
- [ ] 別のユーザーを作成する
- [ ] 面接官用の面接日程一覧ページへ行く
- [ ] 任意の面接日程を承認する 
- [ ] 別の日程を承認し、現在の面接日時が変更されたことを確認する
- [ ] 面接日程が承認されたユーザーにログインする
- [ ] 面接一覧ページで面接が承認されていることを確認する

その他
---

後半第2章部分のプルリクエストとなっております。
レビューよろしくお願いいたします！
